### PR TITLE
Adds browserify build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /old
 node_modules
 npm-debug.log
+public/javascripts/bundle.js
 .DS_Store
+*.swp

--- a/README.md
+++ b/README.md
@@ -8,6 +8,28 @@ Castlemind is a simple game, designed to promote good problem-solving skills in 
 
 An initial prototype for the game was designed by Chris Kelly, for youth enrichment courses he taught, and after some debate, decided that a virtual experience would be an excellent, and more easily distributed solution to mass-production of the physical product.
 
+## Installation
+
+Install gulp for building the client:
+
+    $ npm install -g gulp
+
+Then, install dependencies:
+
+    $ npm install
+
+Run tests:
+
+    $ npm test
+
+Build the client (will run watch task):
+
+    $ gulp
+
+And start the server at [http://localhost:3000](http://localhost:3000):
+
+    $ npm start
+
 ---
 ###Development
 The development lifecycle of this project wil consist of 4 stages, each taking approximately 2 weeks for completion

--- a/client/index.js
+++ b/client/index.js
@@ -1,0 +1,4 @@
+var makeGame = require('./makeGame');
+
+window.onload = makeGame.init;
+

--- a/client/makeGame.js
+++ b/client/makeGame.js
@@ -1,5 +1,3 @@
-window.onload = init;
-
 function init() {
 	// Page Variables //
 	var divGrid = document.getElementById('divGrid');
@@ -50,3 +48,8 @@ function newSquare(squareData) {
 
 	return square;
 }//end newSquare()
+
+module.exports = {
+  init: init
+};
+

--- a/gulpfile.js
+++ b/gulpfile.js
@@ -1,0 +1,22 @@
+var gulp = require('gulp');
+var gutil = require('gulp-util');
+var source = require('vinyl-source-stream');
+var watchify = require('watchify');
+var browserify = require('browserify');
+
+var bundler = watchify(browserify('./client/index.js', watchify.args));
+
+function bundle() {
+  // https://github.com/gulpjs/gulp/blob/master/docs/recipes/fast-browserify-builds-with-watchify.md
+  return bundler.bundle()
+    .on('error', gutil.log.bind(gutil, 'Browserify Error'))
+    .pipe(source('bundle.js'))
+    .pipe(gulp.dest('./public/javascripts'));
+}
+
+bundler.on('update', bundle);
+bundler.on('log', gutil.log);
+
+gulp.task('js', bundle);
+gulp.task('default', ['js']);
+

--- a/package.json
+++ b/package.json
@@ -24,5 +24,12 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/Nic-Wolf/castlemind/issues"
+  },
+  "devDependencies": {
+    "browserify": "~9.0.3",
+    "gulp": "~3.8.11",
+    "gulp-util": "~3.0.4",
+    "vinyl-source-stream": "~1.1.0",
+    "watchify": "~2.4.0"
   }
 }

--- a/views/index.jade
+++ b/views/index.jade
@@ -2,5 +2,5 @@ extends layout
 
 block content
 	h1= title
-	script(src="/javascripts/makeGame.js")
+	script(src="/javascripts/bundle.js")
 	#divGrid


### PR DESCRIPTION
Adds client-side compilation using browserify (http://browserify.org/) and gulp (http://gulpjs.com/). To build the client-side application (and rebuild on changes), use:

```
$ npm install -g gulp
$ npm install
$ gulp
```

Note that for client-side scripts are now in `client/`; the `public` directory should only contain the compiled files built by browserify.
