### PR TITLE
Adds Vagrant install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ npm-debug.log
 newrelic_agent.log
 .DS_Store
 *.swp
+.vagrant

--- a/README.Vagrant.md
+++ b/README.Vagrant.md
@@ -1,0 +1,40 @@
+Vagrant Instructions
+========================================================
+
+A Vagrant configuration is included for local development of castlemind. To use
+it, you will need:
+
+  * [VirtualBox](https://www.virtualbox.org/)
+  * [ansible](https://ansible.com) >= 1.7
+  * [Vagrant](https://vagrantup.com) >= 1.6.5
+
+### Installation
+
+    $ git clone git@github.com:nic-wolf/castlemind
+    $ cd castlemind
+    $ ansible-galaxy install rjzaworski.nodeapp
+    $ vagrant up
+
+The castlemind application will now be running on a VM at `192.168.32.30`:
+
+    $ curl 192.168.32.30
+
+### Development
+
+The host machine's `castlemind` directory is synced on the Vagrant VM at
+`/home/vagrant/castlemind`:
+
+    $ vagrant ssh
+    vagrant@precise64:~$ cd ~/castlemind
+
+The application is managed using upstart; to restart it, ssh on to the VM and
+run the restart job:
+
+    $ vagrant ssh
+    vagrant@precise64:~$ sudo service castlemind restart
+
+Confirm that one (or both) worker processes are up and running:
+
+    vagrant@precise64:~$ sudo tail /var/log/upstart/castlemind-worker-1.log
+    vagrant@precise64:~$ sudo tail /var/log/upstart/castlemind-worker-2.log
+

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,0 +1,31 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+VAGRANTFILE_API_VERSION = '2'
+
+Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
+
+  # Build a new VM without much memory
+  config.vm.define 'vagrant_castlemind' do |web|
+
+    # Base the VM on Ubuntu Precise (14.04 / LTS release)
+    web.vm.box = 'hashicorp/precise64'
+
+    # Expose the VM at 192.168.32.30
+    web.vm.network 'private_network', ip: '192.168.32.30'
+
+    # Expose the current directory to the host machine at ~/castlemind
+    web.vm.synced_folder '.', '/home/vagrant/castlemind'
+
+  end
+
+  # Provision the host(s)
+  config.vm.provision 'ansible' do |ansible|
+    ansible.playbook = 'provisioning/playbook.yml'
+    ansible.groups = {
+      'castlemind' => ['vagrant_castlemind']
+    }
+  end
+
+end
+

--- a/newrelic.js
+++ b/newrelic.js
@@ -19,6 +19,9 @@ exports.config = {
      * issues with the agent, 'info' and higher will impose the least overhead on
      * production applications.
      */
-    level : 'info'
+    level : 'info',
+
+    filepath: require('path').resolve(__dirname, './newrelic_agent.log')
   }
 };
+

--- a/provisioning/group_vars/castlemind.yml
+++ b/provisioning/group_vars/castlemind.yml
@@ -1,0 +1,51 @@
+---
+app_root: /home/vagrant
+
+nodeapp_name: castlemind
+nodeapp_user: vagrant
+nodeapp_index: '{{ app_root }}/{{ nodeapp_name }}/bin/www'
+nodeapp_node_version: 0.10.33
+nodeapp_num_workers: 2
+nodeapp_env:
+  NODE_ENV: production
+  PORT: "`printf '32%02i' $NODEAPP_INDEX`"
+
+nginx_http_params:
+  gzip_comp_level: 6
+  gzip_vary: 'on'
+  gzip_min_length: 1000
+  gzip_proxied: any
+  gzip_types: 'text/plain text/html text/css application/json application/x-javascript text/xml application/xml application/xml+rss text/javascript'
+  gzip_buffers: '16 8k'
+
+  proxy_cache_path: '/var/cache/nginx levels=1:2 keys_zone=one:8m max_size=3000m inactive=600m'
+  proxy_temp_path: '/var/tmp'
+
+nginx_upstreams:
+  - name: app_proxy
+    servers:
+      - 127.0.0.1:3201
+      - 127.0.0.1:3202
+
+nginx_sites:
+ - server:
+    file_name: castlemind
+    listen: 80
+    root: '{{ app_root }}/{{nodeapp_name}}'
+
+    error_page: 404 /errors/404.html
+    error_page: 500 501 502 503 504 /errors/5xx.html
+
+    location1:
+      name: /
+      proxy_pass: http://app_proxy/
+      proxy_redirect: 'off'
+      proxy_read_timeout: 2 # seconds
+      proxy_set_header: 'Host $host'
+      proxy_set_header: 'X-Real-IP $remote_addr'
+      proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+      proxy_http_version: 1.1
+
+      proxy_cache: 'one'
+      proxy_cache_key: 'sfs$request_uri$scheme'
+

--- a/provisioning/playbook.yml
+++ b/provisioning/playbook.yml
@@ -1,0 +1,8 @@
+---
+- hosts: castlemind
+  sudo: yes
+  roles:
+  - nginx
+  - rjzaworski.nodeapp
+  - castlemind
+

--- a/provisioning/roles/castlemind/tasks/main.yml
+++ b/provisioning/roles/castlemind/tasks/main.yml
@@ -1,0 +1,4 @@
+---
+- include: ufw.yml
+- include: newrelic.yml
+

--- a/provisioning/roles/castlemind/tasks/newrelic.yml
+++ b/provisioning/roles/castlemind/tasks/newrelic.yml
@@ -1,0 +1,6 @@
+- name: ensure newrelic_agent.log exists
+  file: path={{ app_root }}/{{ nodeapp_name }}/newrelic_agent.log state=touch owner={{ nodeapp_user }} mode=0644
+
+- name: restart node app
+  service: name={{ nodeapp_name }} state=restarted
+

--- a/provisioning/roles/castlemind/tasks/ufw.yml
+++ b/provisioning/roles/castlemind/tasks/ufw.yml
@@ -1,0 +1,13 @@
+---
+- name: (ufw) deny all incoming
+  ufw: state=enabled policy=deny direction=incoming
+
+- name: (ufw) allow ssh
+  ufw: rule=allow port=ssh
+
+- name: (ufw) allow www
+  ufw: rule=allow port=www
+
+- name: (ufw) reload
+  ufw: state=reloaded
+

--- a/provisioning/roles/nginx/README.md
+++ b/provisioning/roles/nginx/README.md
@@ -1,0 +1,172 @@
+nginx
+=====
+
+This role installs and configures the nginx web server. The user can specify
+any http configuration parameters they wish to apply their site. Any number of
+sites can be added with configurations of your choice.
+
+Requirements
+------------
+
+This role requires Ansible 1.4 or higher and platform requirements are listed
+in the metadata file.
+
+Role Variables
+--------------
+
+The variables that can be passed to this role and a brief description about
+them are as follows.
+
+    # The max clients allowed
+    nginx_max_clients: 512                                
+
+    # A hash of the http paramters. Note that any
+    # valid nginx http paramters can be added here.
+    # (see the nginx documentation for details.)
+    nginx_http_params:                                    
+      sendfile: "on"                                      
+      tcp_nopush: "on"
+      tcp_nodelay: "on"
+      keepalive_timeout: "65"
+      access_log: "/var/log/nginx/access.log"
+      error_log: "/var/log/nginx/error.log"
+
+    # A list of hashs that define the servers for nginx,
+    # as with http parameters. Any valid server parameters
+    # can be defined here.
+    nginx_sites:                                         
+     - server:                                           
+        file_name: foo
+        listen: 8080
+        server_name: localhost
+        root: "/tmp/site1"
+        location1: {name: /, try_files: "$uri $uri/ /index.html"}
+        location2: {name: /images/, try_files: "$uri $uri/ /index.html"}
+     - server:
+        file_name: bar
+        listen: 9090
+        server_name: ansible
+        root: "/tmp/site2"
+        location1: {name: /, try_files: "$uri $uri/ /index.html"}
+        location2: {name: /images/, try_files: "$uri $uri/ /index.html"}
+
+Examples
+========
+
+1) Install nginx with HTTP directives of choices, but with no sites
+configured:
+
+    - hosts: all
+      roles:
+      - {role: nginx,
+         nginx_http_params: { sendfile: "on",
+                              access_log: "/var/log/nginx/access.log"},
+                              nginx_sites: none }
+
+
+2) Install nginx with different HTTP directives than previous example, but no
+sites configured.
+
+    - hosts: all
+      roles:
+      - {role: nginx,
+         nginx_http_params: { tcp_nodelay: "on",
+                              error_log: "/var/log/nginx/error.log"}, 
+                              nginx_sites: none }
+
+Note: Please make sure the HTTP directives passed are valid, as this role
+won't check for the validity of the directives. See the nginx documentation
+for details.
+
+3) Install nginx and add a site to the configuration.
+
+    - hosts: all
+
+      roles:
+      - role: nginx,
+        nginx_http_params:
+          sendfile: "on"
+          access_log: "/var/log/nginx/access.log"
+          nginx_sites:
+          - server:
+             file_name: bar
+             listen: 8080
+             location1: {name: "/", try_files: "$uri $uri/ /index.html"}
+             location2: {name: /images/, try_files: "$uri $uri/ /index.html"}
+
+Note: Each site added is represented by list of hashes, and the configurations
+generated are populated in `/etc/nginx/sites-available/` and have corresponding
+symlinks from `/etc/nginx/sites-enabled/`
+
+The file name for the specific site configurtaion is specified in the hash
+with the key "file_name", any valid server directives can be added to hash.
+For location directive add the key "location" suffixed by a unique number, the
+value for the location is hash, please make sure they are valid location
+directives.
+
+4) Install Nginx and add 2 sites (different method)
+
+    ---
+    - hosts: all
+      roles:
+        - role: nginx
+          nginx_http_params:
+            sendfile: "on"
+            access_log: "/var/log/nginx/access.log"
+          nginx_sites:
+           - server:
+              file_name: foo
+              listen: 8080
+              server_name: localhost
+              root: "/tmp/site1"
+              location1: {name: /, try_files: "$uri $uri/ /index.html"}
+              location2: {name: /images/, try_files: "$uri $uri/ /index.html"}
+           - server:
+              file_name: bar
+              listen: 9090
+              server_name: ansible
+              root: "/tmp/site2"
+              location1: {name: /, try_files: "$uri $uri/ /index.html"}
+              location2: {name: /images/, try_files: "$uri $uri/ /index.html"}
+
+
+5) Install Nginx as proxy for another app
+
+    - hosts: all
+      roles:
+        - role: nginx,
+          nginx_upstreams:
+          - name: app_proxy
+            server: 127.0.0.1:3200
+          nginx_sites:
+           - server:
+              file_name: foo
+              server_name: 'ansible'
+              listen: 8080
+              location1:
+                - name: /
+                  proxy_pass: http://app_proxy/
+                  proxy_redirect:  'off'
+                  proxy_set_header: 'Host $host'
+                  proxy_set_header: 'X-Real-IP $remote_addr'
+                  proxy_set_header: 'X-Forwarded-For $proxy_add_x_forwarded_for'
+
+
+
+
+Dependencies
+------------
+
+None
+
+License
+-------
+
+BSD
+
+Author Information
+------------------
+
+Benno Joy
+
+

--- a/provisioning/roles/nginx/defaults/main.yml
+++ b/provisioning/roles/nginx/defaults/main.yml
@@ -1,0 +1,32 @@
+---
+
+nginx_max_clients: 512
+
+nginx_http_params:
+  sendfile: "on"
+  tcp_nopush: "on"
+  tcp_nodelay: "on"
+  keepalive_timeout: "65"
+
+nginx_log_dir: "/var/log/nginx"
+nginx_access_log_name: "access.log"
+nginx_error_log_name: "error.log"
+nginx_separete_logs_per_site: False
+
+nginx_upstreams: []
+
+nginx_sites:
+ - server:
+    file_name: foo
+    listen: 8080
+    server_name: localhost
+    root: "/tmp/site1"
+    location1: {name: /, try_files: "$uri $uri/ /index.html"}
+    location2: {name: /images/, try_files: "$uri $uri/ /index.html"}
+ - server:
+    file_name: bar
+    listen: 9090
+    server_name: ansible
+    root: "/tmp/site2"
+    location1: {name: /, try_files: "$uri $uri/ /index.html"}
+    location2: {name: /images/, try_files: "$uri $uri/ /index.html"}

--- a/provisioning/roles/nginx/files/epel.repo
+++ b/provisioning/roles/nginx/files/epel.repo
@@ -1,0 +1,26 @@
+[epel]
+name=Extra Packages for Enterprise Linux 6 - $basearch
+baseurl=http://download.fedoraproject.org/pub/epel/6/$basearch
+#mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-6&arch=$basearch
+failovermethod=priority
+enabled=1
+gpgcheck=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
+
+[epel-debuginfo]
+name=Extra Packages for Enterprise Linux 6 - $basearch - Debug
+#baseurl=http://download.fedoraproject.org/pub/epel/6/$basearch/debug
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-debug-6&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
+gpgcheck=1
+
+[epel-source]
+name=Extra Packages for Enterprise Linux 6 - $basearch - Source
+#baseurl=http://download.fedoraproject.org/pub/epel/6/SRPMS
+mirrorlist=https://mirrors.fedoraproject.org/metalink?repo=epel-source-6&arch=$basearch
+failovermethod=priority
+enabled=0
+gpgkey=file:///etc/pki/rpm-gpg/RPM-GPG-KEY-EPEL-6
+gpgcheck=1

--- a/provisioning/roles/nginx/handlers/main.yml
+++ b/provisioning/roles/nginx/handlers/main.yml
@@ -1,0 +1,6 @@
+---
+- name: restart nginx
+  service: name=nginx state=restarted 
+
+- name: reload nginx
+  service: name=nginx state=reloaded

--- a/provisioning/roles/nginx/meta/main.yml
+++ b/provisioning/roles/nginx/meta/main.yml
@@ -1,0 +1,26 @@
+---
+galaxy_info:
+  author: "Benno Joy"
+  company: AnsibleWorks
+  license: BSD
+  min_ansible_version: 1.4
+  platforms:
+   - name: EL
+     versions:
+      - 5
+      - 6
+   - name: Fedora
+     versions:
+      - 16
+      - 17
+      - 18
+   - name: Ubuntu
+     versions:
+      - precise
+      - quantal
+      - raring
+      - saucy
+  categories:
+   - web
+dependencies: []
+  

--- a/provisioning/roles/nginx/tasks/main.yml
+++ b/provisioning/roles/nginx/tasks/main.yml
@@ -1,0 +1,56 @@
+---
+
+- name: Install the selinux python module
+  yum: name=libselinux-python state=present
+  when: ansible_os_family == "RedHat"
+
+- name: Copy the epel packages 
+  copy: src=epel.repo dest=/etc/yum.repos.d/epel_ansible.repo
+  when: ansible_os_family == "RedHat"
+
+- name: Install the nginx packages 
+  yum: name={{ item }} state=present
+  with_items: redhat_pkg
+  when: ansible_os_family == "RedHat"
+
+- name: Install the nginx packages 
+  apt: name={{ item }} state=present update_cache=yes
+  with_items: ubuntu_pkg
+  environment: env
+  when: ansible_os_family == "Debian"
+
+- name: Create the directories for site specific configurations
+  file: path=/etc/nginx/{{ item }} state=directory owner=root group=root mode=0755
+  with_items:
+    - "sites-available"
+    - "sites-enabled"
+
+- name: Copy the nginx configuration file 
+  template: src=nginx.conf.j2 dest=/etc/nginx/nginx.conf
+  notify: 
+   - restart nginx
+
+- name: Copy the nginx default configuration file 
+  template: src=default.conf.j2 dest=/etc/nginx/conf.d/default.conf
+
+- name: Copy the nginx default site configuration file 
+  template: src=default.j2 dest=/etc/nginx/sites-available/default
+
+- name: Create the link for site enabled specific configurations
+  file: path=/etc/nginx/sites-enabled/default state=link src=/etc/nginx/sites-available/default 
+
+- name: Create the configurations for sites
+  template: src=site.j2 dest=/etc/nginx/sites-available/{{ item['server']['file_name'] }}
+  with_items: nginx_sites
+  when: nginx_sites|lower != 'none'
+
+- name: Create the links to enable site configurations
+  file: path=/etc/nginx/sites-enabled/{{ item['server']['file_name'] }} state=link src=/etc/nginx/sites-available/{{ item['server']['file_name'] }}
+  with_items: nginx_sites
+  when: nginx_sites|lower != 'none'
+  notify: 
+   - reload nginx
+
+- name: start the nginx service
+  service: name=nginx state=started enabled=yes
+

--- a/provisioning/roles/nginx/templates/default.conf.j2
+++ b/provisioning/roles/nginx/templates/default.conf.j2
@@ -1,0 +1,1 @@
+#{{ ansible_managed }}

--- a/provisioning/roles/nginx/templates/default.j2
+++ b/provisioning/roles/nginx/templates/default.j2
@@ -1,0 +1,1 @@
+#{{ ansible_managed }}

--- a/provisioning/roles/nginx/templates/nginx.conf.j2
+++ b/provisioning/roles/nginx/templates/nginx.conf.j2
@@ -1,0 +1,50 @@
+#{{ ansible_managed }}
+{% if ansible_os_family == 'RedHat' %} 
+user              nginx;
+{% endif %}
+{% if ansible_os_family == 'Debian' %} 
+user              www-data;
+{% endif %}
+
+worker_processes  {{ ansible_processor_count }};
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  {{ nginx_max_clients }};
+}
+
+
+http {
+
+        include /etc/nginx/mime.types;
+        default_type application/octet-stream;
+
+        access_log {{ nginx_log_dir}}/{{ nginx_access_log_name}};
+        error_log {{ nginx_log_dir}}/{{ nginx_error_log_name}};
+
+{% for k,v in nginx_http_params.iteritems() %}
+        {{ k }}  {{ v }};
+{% endfor %}
+
+        gzip on;
+        gzip_disable "msie6";
+
+{% for upstream in nginx_upstreams %}
+        upstream {{ upstream.name }} {
+{% for k,v in upstream.iteritems() %}
+{% if k != 'name' and k != 'servers' %}
+          {{ k }} {{ v }};
+{% endif %}
+{% endfor %}
+{% if 'servers' in upstream %}
+{% for server in upstream.servers %}
+          server {{ server }};
+{% endfor %}
+{% endif %}
+        }
+{% endfor %}
+
+        include /etc/nginx/conf.d/*.conf;
+        include /etc/nginx/sites-enabled/*;
+}

--- a/provisioning/roles/nginx/templates/site.j2
+++ b/provisioning/roles/nginx/templates/site.j2
@@ -1,0 +1,22 @@
+server {
+
+{% if nginx_separete_logs_per_site == True %}
+	access_log {{ nginx_log_dir}}/{{ item.server.server_name}}-{{ nginx_access_log_name}};
+	error_log {{ nginx_log_dir}}/{{ item.server.server_name}}-{{ nginx_error_log_name}};
+{% endif %}
+
+{% for k,v in item.server.iteritems() %}
+{% if k.find('location') == -1 and k != 'file_name' %}
+{{ k }} {{ v }};
+{% endif %}
+{% endfor %} 
+
+{% for k,v in item.server.iteritems() if k.find('location') != -1 %}
+  location {{ v.name }} {
+{% for x,y in v.iteritems() if x != 'name' %} 
+      {{ x }} {{ y }};
+{% endfor %}
+  }
+{% endfor %}
+}
+

--- a/provisioning/roles/nginx/vars/main.yml
+++ b/provisioning/roles/nginx/vars/main.yml
@@ -1,0 +1,13 @@
+---
+
+env:
+ RUNLEVEL: 1
+
+redhat_pkg:
+  - nginx
+
+ubuntu_pkg:
+  - python-selinux
+  - nginx
+
+  


### PR DESCRIPTION
For @Nic-Wolf, here's a dev environment (Ubuntu 14.04) built on vagrant. The built VM ships with:
- the app folder synced from the host to the vagrant VM at `/home/vagrant/castlemind`
- a locally accessible IP (`192.168.32.30`)
- two app instances (bound to `:3201` and `:3202`) and an nginx instance (`:80`) up and running
- very basic upstart and nginx configurations for managing the app and proxying requests
